### PR TITLE
Add different error when entering empty comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,6 +7,8 @@ class CommentsController < ApplicationController
     initialize_comment
     if @comment.save
       flash[:notice] = "You have commented on #{@movie.title}. Thank you."
+    elsif @comment.message.empty?
+      flash[:danger] = 'Failed to add new comment. It can\'t be empty!'
     else
       flash[:danger] = 'Failed to add new comment. Delete previous one first!'
     end


### PR DESCRIPTION
Added new condition to check if written comment is empty, and in case it is - user gets different error message after trying to submit it.